### PR TITLE
add codecov to report code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 
 # ignored file types
 *.pyc
+.coverage
+
+testing/coverage/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ install:
   - conda env create -f envs/environment.yaml
   - source activate m2s
   - conda list
+  - pip install codecov
 
 script: 
   - make unittests
+
+after_success:
+  - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 unittests:
 	@echo "Unittesting Model2Service..."
-	@nosetests --all-modules --verbose --exe m2s/tests
+	@nosetests --nocapture --nologcapture  --all-modules --verbose --exe m2s/tests --cover-package=m2s --with-coverage --cover-inclusive --cover-erase --cover-html --cover-html-dir=testing/coverage

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -12,3 +12,4 @@ dependencies:
   - pytorch::torchvision
   - overrides
   - flask
+  - coverage


### PR DESCRIPTION
this PR adds codecov library to report coverage before and after code changes. The aim is to always prevent changes from being merged if they decrease the code coverage.